### PR TITLE
Added support for crowdsec openresty bouncer.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ARG DOCKER_IMAGE_VERSION=unknown
 
 # Define software versions.
 ARG OPENRESTY_VERSION=1.19.9.1
-ARG CROWDSEC_OPENRESTY_BOUNCER_VERSION=0.1.0
+ARG CROWDSEC_OPENRESTY_BOUNCER_VERSION=0.1.1
 ARG NGINX_PROXY_MANAGER_VERSION=2.9.15
 ARG NGINX_HTTP_GEOIP2_MODULE_VERSION=3.3
 ARG LIBMAXMINDDB_VERSION=1.5.0
@@ -385,9 +385,11 @@ RUN \
     mkdir -p /crowdsec/ && \
     cp /tmp/crowdsec-openresty-bouncer/openresty/crowdsec_openresty.conf /crowdsec/crowdsec_openresty.conf && \
     sed-patch 's|/etc/crowdsec/bouncers/crowdsec-openresty-bouncer.conf|/config/crowdsec-openresty-bouncer.conf|' /crowdsec/crowdsec_openresty.conf && \
-    sed-patch 's|/usr/local/openresty/lualib/plugins/crowdsec|/var/lib/nginx/lualib/plugins/crowdsec|' /crowdsec/crowdsec_openresty.conf && \
-    sed-patch 's|$prefix/../lualib/plugins/crowdsec|/var/lib/nginx/lualib/plugins/crowdsec|' /crowdsec/crowdsec_openresty.conf && \
-    cp /tmp/crowdsec-openresty-bouncer/config/template.conf /crowdsec/crowdsec-openresty-bouncer.conf && \
+    sed-patch 's|$prefix/../lualib/plugins/crowdsec|/var/lib/nginx/lualib|' /crowdsec/crowdsec_openresty.conf && \
+    sed-patch 's|resolver local=on ipv6=off;||' /crowdsec/crowdsec_openresty.conf && \
+    sed-patch 's|${SSL_CERTS_PATH}|/etc/ssl/certs/ca-certificates.crt|' /crowdsec/crowdsec_openresty.conf && \
+    cp -r /tmp/crowdsec-openresty-bouncer/templates /crowdsec/ && \
+    cp /tmp/crowdsec-openresty-bouncer/config/config_example.conf /crowdsec/crowdsec-openresty-bouncer.conf && \
     cp -r /tmp/crowdsec-openresty-bouncer/lua /crowdsec/ && \
     # Cleanup.
     rm -rf /tmp/* /tmp/.[!.]*

--- a/rootfs/etc/cont-init.d/99-crowdsec.sh
+++ b/rootfs/etc/cont-init.d/99-crowdsec.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/with-contenv sh
+
+set -e # Exit immediately if a command exits with a non-zero status.
+set -u # Treat unset variables as an error.
+
+log() {
+    echo "[cont-init.d] $(basename $0): $*"
+}
+
+if [ ${CROWDSEC_BOUNCER} == "1" ]; then
+    #Install Crowdsec Bouncer Config.
+    [ -f /config/crowdsec-openresty-bouncer.conf ] || cp /crowdsec/crowdsec-openresty-bouncer.conf /config/crowdsec-openresty-bouncer.conf
+    mkdir -p /var/lib/nginx/lualib/plugins/crowdsec/
+    cp /crowdsec/lua/* /var/lib/nginx/lualib/plugins/crowdsec/
+    cp /crowdsec/crowdsec_openresty.conf /etc/nginx/conf.d/
+fi
+

--- a/rootfs/etc/cont-init.d/99-crowdsec.sh
+++ b/rootfs/etc/cont-init.d/99-crowdsec.sh
@@ -10,8 +10,9 @@ log() {
 if [ ${CROWDSEC_BOUNCER} == "1" ]; then
     #Install Crowdsec Bouncer Config.
     [ -f /config/crowdsec-openresty-bouncer.conf ] || cp /crowdsec/crowdsec-openresty-bouncer.conf /config/crowdsec-openresty-bouncer.conf
-    mkdir -p /var/lib/nginx/lualib/plugins/crowdsec/
-    cp /crowdsec/lua/* /var/lib/nginx/lualib/plugins/crowdsec/
+    mkdir -p /var/lib/nginx/lualib/ /var/lib/crowdsec/lua/
+    cp -r /crowdsec/lua/lib/* /var/lib/nginx/lualib/
     cp /crowdsec/crowdsec_openresty.conf /etc/nginx/conf.d/
+    cp -r /crowdsec/templates /var/lib/crowdsec/lua/
 fi
 


### PR DESCRIPTION
https://github.com/NginxProxyManager/nginx-proxy-manager/issues/1131

It can be enabled by setting the environment variable CROWDSEC_BOUNCER=1
The config file crowdsec-openresty-bouncer.conf will be available in /config/ for editing.